### PR TITLE
test+ci: JWT contract tests, Postgres in GHA, GET /me integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,20 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PYTHONPATH: ${{ github.workspace }}
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: zhuchka
+          POSTGRES_PASSWORD: zhuchka
+          POSTGRES_DB: zhuchka_directory_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U zhuchka -d zhuchka_directory_test"
+          --health-interval 2s
+          --health-timeout 5s
+          --health-retries 30
     steps:
       - uses: actions/checkout@v4
 
@@ -35,8 +49,14 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
 
-      - name: Config for tests
-        run: cp config.ini.example config.ini
+      - name: Config for CI (Postgres service)
+        run: python scripts/ci_prep_config.py
+
+      - name: Alembic config
+        run: cp alembic.ini.example alembic.ini
+
+      - name: Database migrations
+        run: alembic upgrade head
 
       - name: Ruff check
         run: ruff check .

--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ Customer directory API (see monorepo `docs/microservices/02-directory.md`): **`G
 - 🧪 **Pytest** for testing
 - 📊 **Logging** configured and ready to use
 - 🔧 **Makefile** for convenient development
-- 🔄 **GitHub Actions**: pytest + Docker build (`.github/workflows/ci.yml`)
+- 🔄 **GitHub Actions**: Ruff, pytest (with Postgres + Alembic), Docker build (`.github/workflows/ci.yml`)
+
+## Testing
+
+- **`tests/test_jwt_decode_contract.py`** — RS256 + `decode_access_token` with a mocked JWKS signing key (no database).
+- **`tests/test_api_v1_me_integration.py`** — `GET /api/v1/me` with Bearer token; marked **`integration`**, **skipped** if Postgres is not reachable (apply migrations locally: `alembic upgrade head`).
+- **CI** provisions **PostgreSQL**, writes **`scripts/ci_prep_config.py`**, runs **`alembic upgrade head`**, then **pytest** so integration tests run on every PR.
 
 ## Quick Start
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    integration: requires Postgres and applied migrations

--- a/scripts/ci_prep_config.py
+++ b/scripts/ci_prep_config.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Write config.ini for GitHub Actions (Postgres service container)."""
+
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_EXAMPLE = _ROOT / "config.ini.example"
+_OUT = _ROOT / "config.ini"
+
+
+def main() -> None:
+    cfg = configparser.ConfigParser()
+    cfg.read(_EXAMPLE)
+    cfg["POSTGRES"]["DATABASE_NAME"] = "zhuchka_directory_test"
+    cfg["POSTGRES"]["USERNAME"] = "zhuchka"
+    cfg["POSTGRES"]["PASSWORD"] = "zhuchka"
+    cfg["POSTGRES"]["IP"] = "127.0.0.1"
+    cfg["POSTGRES"]["PORT"] = "5432"
+    with _OUT.open("w", encoding="utf-8") as f:
+        cfg.write(f)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api_v1_me_integration.py
+++ b/tests/test_api_v1_me_integration.py
@@ -1,0 +1,103 @@
+"""API smoke with Bearer JWT when Postgres is reachable (CI or local dev)."""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from types import SimpleNamespace
+
+import jwt
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt import PyJWK
+from jwt.algorithms import RSAAlgorithm
+from sqlalchemy import text
+from starlette.testclient import TestClient
+
+ISS = "http://127.0.0.1:8000"
+AUD = "zhuchka-api"
+
+
+@pytest.fixture(scope="session")
+def postgres_reachable() -> None:
+    """Skip integration tests if the app cannot open a DB connection."""
+    import asyncio
+
+    from src.database.core import engine
+
+    async def ping() -> None:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+
+    try:
+        asyncio.run(ping())
+    except Exception as exc:
+        pytest.skip(f"Postgres not reachable for integration tests: {exc}")
+
+
+@pytest.fixture
+def rsa_private():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+
+
+def _signing_key_from_private(rsa_private):
+    pub = rsa_private.public_key()
+    jwk_dict = RSAAlgorithm.to_jwk(pub, as_dict=True)
+    jwk_dict["kid"] = "test-kid"
+    jwk_dict["use"] = "sig"
+    jwk_dict["alg"] = "RS256"
+    return PyJWK.from_json(json.dumps(jwk_dict))
+
+
+def _fake_jwks_client(signing_key: PyJWK):
+    class Fake:
+        def get_signing_key_from_jwt(self, token):  # noqa: ARG002
+            return signing_key
+
+    return Fake()
+
+
+def _access_token(rsa_private, subject: str) -> str:
+    now = int(time.time())
+    claims = {
+        "sub": subject,
+        "iss": ISS,
+        "aud": AUD,
+        "exp": now + 3600,
+        "iat": now,
+        "token_use": "access",
+        "scope": "profile",
+    }
+    return jwt.encode(claims, rsa_private, algorithm="RS256", headers={"kid": "test-kid"})
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("postgres_reachable")
+def test_get_me_lazy_provision(monkeypatch, rsa_private) -> None:
+    """GET /api/v1/me returns 200 and creates a profile row keyed by JWT sub."""
+    signing_key = _signing_key_from_private(rsa_private)
+    monkeypatch.setattr("src.auth_token._jwks_client", _fake_jwks_client(signing_key))
+    monkeypatch.setattr(
+        "src.auth_token._auth_cfg",
+        SimpleNamespace(jwks_url="http://fixture.invalid/jwks", issuer=ISS, audience=AUD),
+    )
+
+    sub = str(uuid.uuid4())
+    token = _access_token(rsa_private, sub)
+
+    from src.main import app
+
+    with TestClient(app) as client:
+        r = client.get("/api/v1/me", headers={"Authorization": f"Bearer {token}"})
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["subject"] == sub
+
+    # Second call is idempotent (same row)
+    with TestClient(app) as client:
+        r2 = client.get("/api/v1/me", headers={"Authorization": f"Bearer {token}"})
+    assert r2.status_code == 200
+    assert r2.json()["id"] == data["id"]

--- a/tests/test_jwt_decode_contract.py
+++ b/tests/test_jwt_decode_contract.py
@@ -1,0 +1,101 @@
+"""JWT decode + RS256 (no network, no Postgres). Refs integration contract for Auth."""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from types import SimpleNamespace
+
+import jwt
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import HTTPException
+from jwt import PyJWK
+from jwt.algorithms import RSAAlgorithm
+
+TEST_ISS = "http://127.0.0.1:8000"
+TEST_AUD = "zhuchka-api"
+
+
+@pytest.fixture
+def rsa_private():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+
+
+def _signing_key_from_private(rsa_private):
+    pub = rsa_private.public_key()
+    jwk_dict = RSAAlgorithm.to_jwk(pub, as_dict=True)
+    jwk_dict["kid"] = "test-kid"
+    jwk_dict["use"] = "sig"
+    jwk_dict["alg"] = "RS256"
+    return PyJWK.from_json(json.dumps(jwk_dict))
+
+
+def _fake_jwks_client(signing_key: PyJWK):
+    class Fake:
+        def get_signing_key_from_jwt(self, token):  # noqa: ARG002
+            return signing_key
+
+    return Fake()
+
+
+def test_decode_access_token_rs256_roundtrip(monkeypatch, rsa_private):
+    signing_key = _signing_key_from_private(rsa_private)
+    monkeypatch.setattr("src.auth_token._jwks_client", _fake_jwks_client(signing_key))
+    monkeypatch.setattr(
+        "src.auth_token._auth_cfg",
+        SimpleNamespace(jwks_url="http://fixture.invalid/jwks", issuer=TEST_ISS, audience=TEST_AUD),
+    )
+
+    sub = str(uuid.uuid4())
+    now = int(time.time())
+    claims_in = {
+        "sub": sub,
+        "iss": TEST_ISS,
+        "aud": TEST_AUD,
+        "exp": now + 3600,
+        "iat": now,
+        "token_use": "access",
+        "scope": "profile",
+    }
+    token = jwt.encode(
+        claims_in,
+        rsa_private,
+        algorithm="RS256",
+        headers={"kid": "test-kid"},
+    )
+
+    from src.auth_token import decode_access_token
+
+    out = decode_access_token(token)
+    assert out["sub"] == sub
+    assert out["token_use"] == "access"
+
+
+def test_decode_access_token_rejects_non_access_token_use(monkeypatch, rsa_private):
+    signing_key = _signing_key_from_private(rsa_private)
+    monkeypatch.setattr("src.auth_token._jwks_client", _fake_jwks_client(signing_key))
+    monkeypatch.setattr(
+        "src.auth_token._auth_cfg",
+        SimpleNamespace(jwks_url="http://fixture.invalid/jwks", issuer=TEST_ISS, audience=TEST_AUD),
+    )
+
+    sub = str(uuid.uuid4())
+    now = int(time.time())
+    claims_in = {
+        "sub": sub,
+        "iss": TEST_ISS,
+        "aud": TEST_AUD,
+        "exp": now + 3600,
+        "iat": now,
+        "token_use": "refresh",
+    }
+    token = jwt.encode(claims_in, rsa_private, algorithm="RS256", headers={"kid": "test-kid"})
+
+    from src.auth_token import decode_access_token
+
+    with pytest.raises(HTTPException) as exc:
+        decode_access_token(token)
+    assert exc.value.status_code == 401


### PR DESCRIPTION
## Summary
- **#1** CI: Postgres 16 service, \scripts/ci_prep_config.py\, \lembic upgrade head\ before pytest; keeps Ruff + Docker build.
- **#6** Tests: \	est_jwt_decode_contract.py\ (mocked JWKS, no DB); \	est_api_v1_me_integration.py\ — \GET /api/v1/me\ with RS256 Bearer (skipped if DB unreachable).
- **#9** README: Testing section.

## Notes
- Integration test uses \@pytest.mark.integration\ + session DB ping; local runs skip if Postgres is not up.
- JWT issuer/audience in tests match \config.ini.example\ \[AUTH]\.

Refs #1 Refs #6 Refs #9

Made with [Cursor](https://cursor.com)