### PR TITLE
feat: /metrics, X-Request-ID, staff JWT scopes (support.*)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,18 @@ A production-ready FastAPI boilerplate designed for rapid project setup — feat
 
 Customer directory API (see monorepo `docs/microservices/02-directory.md`): **`GET/PATCH /api/v1/me`**, **`GET/POST/PATCH/DELETE /api/v1/me/addresses`**, **`GET/POST /api/v1/me/consents`**, **`GET/POST/DELETE /api/v1/me/b2b-links`** require a **Bearer** access token from Auth (`RS256`); configure **`[AUTH]`** in `config.ini` (`JWKS_URL`, `ISSUER`, `AUDIENCE` must match the authorization server). The first successful `GET /me` creates a profile row keyed by JWT `sub`. At most one address per customer may be marked **default** (`is_default`); setting it clears `is_default` on other rows. Consents are stored per **privacy** / **marketing** with **document version**; `GET /me/consents` returns only active rows (not withdrawn). **B2B links** store **`counterparty_id`** (UUID in counterparties service) and **`contact_role`** per customer; duplicate pair returns **409**.
 
-**Operational (staff):** same Bearer token; JWT **`scope`** must include **`support.read`** or **`support.write`** or **`admin`** for **`GET /api/v1/customers`** and **`GET /api/v1/customers/{id}`**; **`support.write`** or **`admin`** for **`PATCH`** and **`POST …/merge`**. **`GET /customers`** supports optional **`counterparty_id`**. **`PATCH`** uses the same body as **`PATCH /me`**; duplicate email returns **409** `email_already_exists`. **`merge`** body: `{ "into_customer_id": "<uuid>" }` — moves addresses, consents, and B2B links into the target, then deletes the source customer.
+**Operational (staff):** same Bearer token; JWT **`scope`** must include **`support.read`** or **`support.write`** or **`admin`** for **`GET /api/v1/customers`** and **`GET /api/v1/customers/{id}`**; **`support.write`** or **`admin`** for **`PATCH`** and **`POST …/merge`**. **`GET /customers`** supports optional **`counterparty_id`**. Details: [docs/AUTH-JWT.md](docs/AUTH-JWT.md). **`PATCH`** uses the same body as **`PATCH /me`**; duplicate email returns **409** `email_already_exists`. **`merge`** body: `{ "into_customer_id": "<uuid>" }` — moves addresses, consents, and B2B links into the target, then deletes the source customer.
 
 **Integration events (outbox):** rows in **`outbox_event`** with types **`directory.customer.created`**, **`directory.customer.updated`**, **`directory.consent.changed`** (JSON payload; published by a separate worker — not part of this service yet).
+
+**Observability:** **`GET /metrics`** (Prometheus), **`X-Request-ID`** on responses, logs include **`[req=…]`** when the id is set.
 
 ## Documentation
 
 | Doc | Content |
 |-----|---------|
 | [docs/CONFIGURATION.md](docs/CONFIGURATION.md) | `config.ini` sections (`POSTGRES`, `UVICORN`, `REDIS`, `AUTH`) |
-| [docs/AUTH-JWT.md](docs/AUTH-JWT.md) | JWKS validation, claims, staff `scope` (`admin`) |
+| [docs/AUTH-JWT.md](docs/AUTH-JWT.md) | JWKS validation, claims, staff `scope` (`support.*` / `admin`) |
 | [DEPLOYMENT.md](DEPLOYMENT.md) | Docker, health endpoints, production checklist |
 
 ## Features

--- a/docs/AUTH-JWT.md
+++ b/docs/AUTH-JWT.md
@@ -11,14 +11,15 @@ Directory validates **OAuth2 access tokens** issued by **Zhuchka Auth** (`servic
 
 Configuration keys: `JWKS_URL`, `ISSUER`, `AUDIENCE` — see [CONFIGURATION.md](CONFIGURATION.md).
 
-## Scopes (current behaviour)
+## Scopes (staff)
 
 | Surface | Requirement |
-|--------|-------------|
-| **Self-service** `/api/v1/me`, `/me/addresses`, `/me/consents`, `/me/b2b-links` | Valid Bearer access token; **no** extra scope checked in code beyond successful JWT validation. Product policy may require `profile` / `customer` on the Auth client — enforce in Auth and document for clients. |
-| **Staff** `/api/v1/customers`, `/api/v1/customers/{id}`, merge | JWT **`scope`** must include **`admin`** (space-separated scopes). Returns **403** `insufficient_scope` otherwise. |
+|--------|---------------|
+| **Self-service** `/api/v1/me`, `/me/addresses`, `/me/consents`, `/me/b2b-links` | Valid Bearer access token; no extra scope checked in this service beyond successful JWT validation. Product policy may require `profile` / `customer` on the Auth client — enforce in Auth and document for clients. |
+| **Staff** `GET /api/v1/customers`, `GET /api/v1/customers/{id}` | JWT **`scope`** (space-separated) includes **`admin`** or **`support.read`** or **`support.write`**. Returns **403** `insufficient_scope` otherwise. |
+| **Staff** `PATCH /api/v1/customers/{id}`, `POST …/merge` | **`admin`** or **`support.write`**. |
 
-Future alignment with `docs/microservices/02-directory.md`: optional split into `support.read` / `support.write` — tracked separately; update this file when implemented.
+The Auth bootstrap OAuth client should list `support.read` and `support.write` in **allowed_scopes** if you mint staff tokens from that client.
 
 ## Operational notes
 

--- a/src/configuration/app.py
+++ b/src/configuration/app.py
@@ -35,7 +35,7 @@ class App:
                 },
                 {
                     "name": TAG_STAFF,
-                    "description": "Operational customer tools; JWT with staff scope (e.g. `admin`).",
+                    "description": "Operational customer tools; JWT `support.read`/`support.write` or `admin` (see docs/AUTH-JWT.md).",
                 },
             ],
         )

--- a/src/middlewares/database.py
+++ b/src/middlewares/database.py
@@ -16,7 +16,7 @@ async def db_session_middleware(request: Request, call_next):
 
     Args:
         request: The incoming request
-        call_next: The next middleware/endpoint in the chain
+        call_next: The next middleware/endpoint in the stack
 
     Returns:
         Response from the next handler

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -11,7 +11,7 @@ def test_metrics_prometheus_text():
         r = client.get("/metrics")
     assert r.status_code == 200
     assert "text/plain" in r.headers.get("content-type", "")
-    assert b"python_info" in r.content or b"# HELP" in r.content
+    assert b"# HELP" in r.content or b"python_info" in r.content
 
 
 def test_x_request_id_echo_and_propagate():


### PR DESCRIPTION
## Summary
- **#7** Observability: \GET /metrics\ (Prometheus), \X-Request-ID\ middleware, log format \[req=…]\ (\src.main:app\).
- **#8** Staff routes: \support.read\ / \support.write\ / \dmin\ — read vs write split per \docs/microservices/02-directory.md\.
- **\docs/AUTH-JWT.md\** — scope table.

## Notes
- Auth bootstrap should allow \support.read\ / \support.write\ on OAuth clients that mint staff tokens (already in monorepo auth if merged).

Refs #7 Refs #8

Made with [Cursor](https://cursor.com)