### PR TITLE
feat: transactional outbox (customer + consent events)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Customer directory API (see monorepo `docs/microservices/02-directory.md`): **`G
 
 - **`tests/test_jwt_decode_contract.py`** — RS256 + `decode_access_token` with a mocked JWKS signing key (no database).
 - **`tests/test_api_v1_me_integration.py`** — `GET /api/v1/me` with Bearer token; marked **`integration`**, **skipped** if Postgres is not reachable (apply migrations locally: `alembic upgrade head`).
+- **`tests/test_outbox_integration.py`** — asserts **`outbox_event`** row for **`directory.customer.created`** after **`GET /me`** (same **`integration`** marker).
 - **CI** provisions **PostgreSQL**, writes **`scripts/ci_prep_config.py`**, runs **`alembic upgrade head`**, then **pytest** so integration tests run on every PR.
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Customer directory API (see monorepo `docs/microservices/02-directory.md`): **`G
 | [docs/AUTH-JWT.md](docs/AUTH-JWT.md) | JWKS validation, claims, staff `scope` (`support.*` / `admin`) |
 | [DEPLOYMENT.md](DEPLOYMENT.md) | Docker, health endpoints, production checklist |
 
+**Events:** profile and consent changes are recorded in the **`outbox_event`** table (transactional outbox): types **`directory.customer.created`**, **`directory.customer.updated`**, **`directory.consent.changed`** with JSON payloads in **`payload`**; a separate worker can publish from this table.
+
 ## Features
 
 - ⚡ **FastAPI** with Python 3.13

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import configparser
 import shutil
 from pathlib import Path
+
+import pytest
+from sqlalchemy import text
 
 _ROOT = Path(__file__).resolve().parent.parent
 _CFG = _ROOT / "config.ini"
@@ -24,3 +28,18 @@ def pytest_configure() -> None:
                 cfg["AUTH"] = dict(ex["AUTH"])
                 with _CFG.open("w", encoding="utf-8") as f:
                     cfg.write(f)
+
+
+@pytest.fixture(scope="session")
+def postgres_reachable() -> None:
+    """Skip integration tests if the app cannot open a DB connection."""
+    from src.database.core import engine
+
+    async def ping() -> None:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+
+    try:
+        asyncio.run(ping())
+    except Exception as exc:
+        pytest.skip(f"Postgres not reachable for integration tests: {exc}")

--- a/tests/test_api_v1_me_integration.py
+++ b/tests/test_api_v1_me_integration.py
@@ -13,28 +13,10 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
 from jwt import PyJWK
 from jwt.algorithms import RSAAlgorithm
-from sqlalchemy import text
 from starlette.testclient import TestClient
 
 ISS = "http://127.0.0.1:8000"
 AUD = "zhuchka-api"
-
-
-@pytest.fixture(scope="session")
-def postgres_reachable() -> None:
-    """Skip integration tests if the app cannot open a DB connection."""
-    import asyncio
-
-    from src.database.core import engine
-
-    async def ping() -> None:
-        async with engine.connect() as conn:
-            await conn.execute(text("SELECT 1"))
-
-    try:
-        asyncio.run(ping())
-    except Exception as exc:
-        pytest.skip(f"Postgres not reachable for integration tests: {exc}")
 
 
 @pytest.fixture

--- a/tests/test_outbox_integration.py
+++ b/tests/test_outbox_integration.py
@@ -1,0 +1,83 @@
+"""Outbox rows written with domain changes when Postgres is up (CI or local)."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import rsa
+from sqlalchemy import text
+from starlette.testclient import TestClient
+
+from src.database.core import async_session_maker
+from src.events.schemas import DIRECTORY_CUSTOMER_CREATED
+from tests.test_api_v1_me_integration import (
+    AUD,
+    ISS,
+    _access_token,
+    _fake_jwks_client,
+    _signing_key_from_private,
+)
+
+
+@pytest.fixture
+def rsa_private():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048, backend=default_backend())
+
+
+async def _count_outbox_created_for_subject(subject: str) -> int:
+    async with async_session_maker() as session:
+        r = await session.execute(
+            text(
+                "SELECT COUNT(*) FROM outbox_event "
+                "WHERE event_type = :et AND payload->>'subject' = :sub"
+            ),
+            {"et": DIRECTORY_CUSTOMER_CREATED, "sub": subject},
+        )
+        return int(r.scalar_one())
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("postgres_reachable")
+def test_get_me_writes_outbox_customer_created(monkeypatch, rsa_private) -> None:
+    signing_key = _signing_key_from_private(rsa_private)
+    monkeypatch.setattr("src.auth_token._jwks_client", _fake_jwks_client(signing_key))
+    monkeypatch.setattr(
+        "src.auth_token._auth_cfg",
+        SimpleNamespace(jwks_url="http://fixture.invalid/jwks", issuer=ISS, audience=AUD),
+    )
+
+    sub = str(uuid.uuid4())
+    token = _access_token(rsa_private, sub)
+
+    from src.main import app
+
+    assert asyncio.run(_count_outbox_created_for_subject(sub)) == 0
+
+    with TestClient(app) as client:
+        r = client.get("/api/v1/me", headers={"Authorization": f"Bearer {token}"})
+
+    assert r.status_code == 200
+    assert asyncio.run(_count_outbox_created_for_subject(sub)) == 1
+
+    payload = asyncio.run(_fetch_latest_payload_dict(sub))
+    assert payload["subject"] == sub
+    assert "customer_id" in payload
+
+
+async def _fetch_latest_payload_dict(subject: str) -> dict:
+    async with async_session_maker() as session:
+        r = await session.execute(
+            text(
+                "SELECT payload FROM outbox_event "
+                "WHERE event_type = :et AND payload->>'subject' = :sub "
+                "ORDER BY created_at DESC LIMIT 1"
+            ),
+            {"et": DIRECTORY_CUSTOMER_CREATED, "sub": subject},
+        )
+        row = r.scalar_one()
+    assert isinstance(row, dict)
+    return row

--- a/tests/test_outbox_schemas.py
+++ b/tests/test_outbox_schemas.py
@@ -1,0 +1,43 @@
+"""Outbox payload schemas (JSON-serializable)."""
+
+from uuid import uuid4
+
+from src.events.schemas import (
+    DIRECTORY_CONSENT_CHANGED,
+    DIRECTORY_CUSTOMER_CREATED,
+    DIRECTORY_CUSTOMER_UPDATED,
+    ConsentChangedPayload,
+    CustomerCreatedPayload,
+    CustomerUpdatedPayload,
+    payload_to_json,
+)
+
+
+def test_event_type_constants():
+    assert DIRECTORY_CUSTOMER_CREATED == "directory.customer.created"
+    assert DIRECTORY_CUSTOMER_UPDATED == "directory.customer.updated"
+    assert DIRECTORY_CONSENT_CHANGED == "directory.consent.changed"
+
+
+def test_payload_to_json_roundtrip_keys():
+    cid = uuid4()
+    sub = uuid4()
+    p = CustomerCreatedPayload(customer_id=cid, subject=sub)
+    d = payload_to_json(p)
+    assert d["customer_id"] == str(cid)
+    assert d["subject"] == str(sub)
+    assert "occurred_at" in d
+
+    p2 = CustomerUpdatedPayload(customer_id=cid, subject=sub)
+    d2 = payload_to_json(p2)
+    assert d2["customer_id"] == str(cid)
+
+    p3 = ConsentChangedPayload(
+        customer_id=cid,
+        consent_type="privacy",
+        document_version="v1",
+        granted=True,
+    )
+    d3 = payload_to_json(p3)
+    assert d3["consent_type"] == "privacy"
+    assert d3["granted"] is True


### PR DESCRIPTION
Closes #5.

## Summary
- Add \outbox_event\ table (JSONB payload) via Alembic \20250328_0005\.
- Wire types \directory.customer.created\, \directory.customer.updated\, \directory.consent.changed\ from profile and consent flows.
- Unit tests for payload schemas; README documents the outbox for downstream workers.

## Test plan
- [x] \pytest\ (local)

Made with [Cursor](https://cursor.com)